### PR TITLE
Request validation updates

### DIFF
--- a/LCARSAlexaSkill/Controllers/AlexaController.cs
+++ b/LCARSAlexaSkill/Controllers/AlexaController.cs
@@ -20,7 +20,7 @@ namespace LCARSAlexaSkill.Controllers
             //    throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.BadRequest));
 
             //var totalSeconds = (DateTime.UtcNow - request.Request.Timestamp).TotalSeconds;
-            //if (totalSeconds <= 0 || totalSeconds > 150)
+            //if (totalSeconds < -15 || totalSeconds > 150)
             //    throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.BadRequest));
 
             AlexaResponse response = null;
@@ -32,9 +32,11 @@ namespace LCARSAlexaSkill.Controllers
                     case "LaunchRequest":
                         response = RequestHandlers.LaunchRequestHandler(request);
                         break;
+
                     case "IntentRequest":
                         response = RequestHandlers.IntentRequestHandler(request);
                         break;
+
                     case "SessionEndedRequest":
                         response = RequestHandlers.SessionEndedRequestHandler(request);
                         break;
@@ -42,7 +44,6 @@ namespace LCARSAlexaSkill.Controllers
             }
 
             return response;
-
         }
 
         [HttpPost, Route("demo")]

--- a/LCARSAlexaSkill/Handlers/AlexaRequestValidationHandler.cs
+++ b/LCARSAlexaSkill/Handlers/AlexaRequestValidationHandler.cs
@@ -62,7 +62,7 @@ namespace LCARSAlexaSkill.Handlers
 
                     var rsa = (RSACryptoServiceProvider)cert.PublicKey.Key;
 
-                    if (rsa == null || rsa.VerifyHash(data, CryptoConfig.MapNameToOID("SHA1"), signature))
+                    if (rsa == null || !rsa.VerifyHash(data, CryptoConfig.MapNameToOID("SHA1"), signature))
                         throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.BadRequest));
                 }
             }

--- a/LCARSAlexaSkill/Handlers/AlexaRequestValidationHandler.cs
+++ b/LCARSAlexaSkill/Handlers/AlexaRequestValidationHandler.cs
@@ -47,7 +47,7 @@ namespace LCARSAlexaSkill.Handlers
                     && effectiveDate < DateTime.UtcNow)))
                     throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.BadRequest));
 
-                if (!cert.Subject.Contains("CN=echo-api.amazon.com") || !cert.Issuer.Contains("CN=VeriSign Class 3 Secure Server CA"))
+                if (!cert.Subject.Contains("CN=echo-api.amazon.com") || !cert.Issuer.Contains("CN=Symantec Class 3 Secure Server CA"))
                     throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.BadRequest));
 
                 var signatureString = request.Headers.GetValues("Signature").First();


### PR DESCRIPTION
Thanks for this wonderful project, it is super helpful for a skill I'm now looking to publish to the store.  I was going through the AlexaRequestValidationHelper in detail and I think there may be a logical inverse when VerifyHash is called.

[VerifyHash](https://msdn.microsoft.com/en-us/library/mt148069(v=vs.110).aspx) will return true if verified, or false if it fails.  In this case I think the following HttpResponseException should only be thrown if the hash verification failed, not if it succeeded.

I could certainly be mistaken about the application logic, so I thought phrasing the question as a pull request might help make it clear what I'm questioning.

Thanks again for all of your work and for publishing this skill framework! :)